### PR TITLE
Fix sipp problems on running.

### DIFF
--- a/lib/sippy_cup/runner.rb
+++ b/lib/sippy_cup/runner.rb
@@ -37,7 +37,7 @@ module SippyCup
         stats_interval = @options[:stats_interval] || 1
         command << " -trace_stat -stf #{@options[:stats_file]} -fd #{stats_interval}"
       end
-      command << "#{@options[:destination]}"
+      command << " #{@options[:destination]}"
       command << " > /dev/null 2>&1" unless @options[:full_sipp_output]
       command
     end


### PR DESCRIPTION
After -s option doesn't have whitespace, when running sipp need
whitespace for interpret remote host.

Invalid
  sudo sipp -i 192.168.1.114 -p 8836 -sf /Users/eloycotopereiro/dev/sipp/sippcup/my_test_scenario.xml -l 10 -m 20 -r 5 -s 1192.168.1.120

Valid
  sudo sipp -i 192.168.1.114 -p 8836 -sf /Users/eloycotopereiro/dev/sipp/sippcup/my_test_scenario.xml -l 10 -m 20 -r 5 -s 1 192.168.1.120

Cheers
