### PR TITLE
[BUGFIX] Fix ACK/BYE being sent to self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   * Feature: receive_message for incoming SIP MESSAGEs.
   * Change: Split `#receive_200` into its own method ([#61](https://github.com/mojolingo/sippy_cup/pull/61))
   * Allow passing arbitrary SIPp options from the YAML manifest
+  * Bugfix: Fix ACK/BYE being sent to self.
 
 # [0.3.0](https://github.com/bklang/sippy_cup/compare/v0.2.3...v0.3.0)
 * Feature: A whole lot more documentation, test coverage and cleaner internals.

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -279,7 +279,7 @@ a=fmtp:101 0-15
 ACK [next_url] SIP/2.0
 Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
 From: "#{@from_user}" <sip:#{@from_user}@[local_ip]>;tag=[call_number]
-[last_To:]
+To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
 Call-ID: [call_id]
 CSeq: [cseq] ACK
 Contact: <sip:#{@from_user}@[local_ip]:[local_port];transport=[transport]>
@@ -364,10 +364,10 @@ Content-Length: 0
       msg = <<-MSG
 
 BYE [next_url] SIP/2.0
-[last_Via:]
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
 From: "#{@from_user}" <sip:#{@from_user}@[local_ip]>;tag=[call_number]
-[last_To:]
-[last_Call-ID]
+To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+Call-ID: [call_id]
 CSeq: [cseq] BYE
 Contact: <sip:#{@from_user}@[local_ip]:[local_port];transport=[transport]>
 Max-Forwards: 100

--- a/spec/sippy_cup/scenario_spec.rb
+++ b/spec/sippy_cup/scenario_spec.rb
@@ -590,7 +590,7 @@ a=fmtp:101 0-15
 ACK [next_url] SIP/2.0
 Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
 From: "sipp" <sip:sipp@[local_ip]>;tag=[call_number]
-[last_To:]
+To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
 Call-ID: [call_id]
 CSeq: [cseq] ACK
 Contact: <sip:sipp@[local_ip]:[local_port];transport=[transport]>
@@ -703,7 +703,7 @@ a=fmtp:101 0-15
 ACK [next_url] SIP/2.0
 Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
 From: "#{specs_from}" <sip:#{specs_from}@[local_ip]>;tag=[call_number]
-[last_To:]
+To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
 Call-ID: [call_id]
 CSeq: [cseq] ACK
 Contact: <sip:#{specs_from}@[local_ip]:[local_port];transport=[transport]>


### PR DESCRIPTION
We shouldn't over-rely on the "last" headers provided by SIPp because
if a 200 OK was sent immediately before then the to/from headers will
be reversed.
