### PR TITLE
[FEATURE] Split receive_200 into its own method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # develop
+  * Change: Split receive_200 into its own method
   * Allow passing arbitrary SIPp options from the YAML manifest
 
 # [0.3.0](https://github.com/bklang/sippy_cup/compare/v0.2.3...v0.3.0)

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -200,7 +200,7 @@ a=fmtp:101 0-15
     # Sets an expectation for a SIP 100 message from the remote party
     #
     # @param [Hash] opts A set of options to modify the expectation
-    # @option opts [true, false] :optional Wether or not receipt of the message is optional. Defaults to true.
+    # @option opts [true, false] :optional Whether or not receipt of the message is optional. Defaults to true.
     #
     def receive_trying(opts = {})
       handle_response 100, opts
@@ -211,7 +211,7 @@ a=fmtp:101 0-15
     # Sets an expectation for a SIP 180 message from the remote party
     #
     # @param [Hash] opts A set of options to modify the expectation
-    # @option opts [true, false] :optional Wether or not receipt of the message is optional. Defaults to true.
+    # @option opts [true, false] :optional Whether or not receipt of the message is optional. Defaults to true.
     #
     def receive_ringing(opts = {})
       handle_response 180, opts
@@ -222,7 +222,7 @@ a=fmtp:101 0-15
     # Sets an expectation for a SIP 183 message from the remote party
     #
     # @param [Hash] opts A set of options to modify the expectation
-    # @option opts [true, false] :optional Wether or not receipt of the message is optional. Defaults to true.
+    # @option opts [true, false] :optional Whether or not receipt of the message is optional. Defaults to true.
     #
     def receive_progress(opts = {})
       handle_response 183, opts
@@ -231,20 +231,29 @@ a=fmtp:101 0-15
 
     #
     # Sets an expectation for a SIP 200 message from the remote party
+    # as well as storing the record set and the response time duration
     #
     # @param [Hash] opts A set of options to modify the expectation
-    # @option opts [true, false] :optional Wether or not receipt of the message is optional. Defaults to true.
+    # @option opts [true, false] :optional Whether or not receipt of the message is optional. Defaults to false.
     #
     def receive_answer(opts = {})
       options = {
-        response: 200,
         rrs: true, # Record Record Set: Make the Route headers available via [route] later
         rtd: true # Response Time Duration: Record the response time
       }
 
-      recv options.merge(opts)
+      receive_200 options.merge(opts)
     end
-    alias :receive_200 :receive_answer
+
+    #
+    # Sets an expectation for a SIP 200 message from the remote party
+    #
+    # @param [Hash] opts A set of options to modify the expectation
+    # @option opts [true, false] :optional Whether or not receipt of the message is optional. Defaults to false.
+    #
+    def receive_200(opts = {})
+      recv({ response: 200 }.merge(opts))
+    end
 
     #
     # Shortcut that sets expectations for optional SIP 100, 180 and 183, followed by a required 200.
@@ -252,9 +261,9 @@ a=fmtp:101 0-15
     # @param [Hash] opts A set of options to modify the expectations
     #
     def wait_for_answer(opts = {})
-      receive_trying({optional: true}.merge opts)
-      receive_ringing({optional: true}.merge opts)
-      receive_progress({optional: true}.merge opts)
+      receive_trying opts
+      receive_ringing opts
+      receive_progress opts
       receive_answer opts
     end
 

--- a/spec/sippy_cup/scenario_spec.rb
+++ b/spec/sippy_cup/scenario_spec.rb
@@ -233,6 +233,26 @@ describe SippyCup::Scenario do
     end
   end
 
+  describe '#receive_200' do
+    it "expects a 200" do
+      subject.receive_200
+
+      scenario.to_xml.should match(%q{<recv response="200"/>})
+    end
+
+    it "allows passing options to the recv expectation" do
+      subject.receive_200 foo: 'bar'
+
+      scenario.to_xml.should match(%q{<recv response="200" foo="bar"/>})
+    end
+
+    it "allows overriding options" do
+      subject.receive_200 response: 999 # Silly but still...
+
+      scenario.to_xml.should match(%q{<recv response="999"/>})
+    end
+  end
+
   describe '#ack_answer' do
     it "sends an ACK message" do
       subject.ack_answer
@@ -276,11 +296,11 @@ describe SippyCup::Scenario do
       scenario.wait_for_answer
 
       xml = scenario.to_xml
-      xml.should =~ /recv optional="true".*response="100"/
-      xml.should =~ /recv optional="true".*response="180"/
-      xml.should =~ /recv optional="true".*response="183"/
+      xml.should =~ /recv response="100".*optional="true"/
+      xml.should =~ /recv response="180".*optional="true"/
+      xml.should =~ /recv response="183".*optional="true"/
       xml.should =~ /recv response="200"/
-      xml.should_not =~ /recv optional="true".*response="200"/
+      xml.should_not =~ /recv response="200".*optional="true"/
     end
 
     it "passes through additional options" do
@@ -546,9 +566,9 @@ a=rtpmap:101 telephone-event/8000
 a=fmtp:101 0-15
 ]]>
 </send>
-  <recv optional="true" response="100"/>
-  <recv optional="true" response="180"/>
-  <recv optional="true" response="183"/>
+  <recv response="100" optional="true"/>
+  <recv response="180" optional="true"/>
+  <recv response="183" optional="true"/>
   <recv response="200" rrs="true" rtd="true"/>
   <send>
 <![CDATA[
@@ -659,9 +679,9 @@ a=rtpmap:101 telephone-event/8000
 a=fmtp:101 0-15
 ]]>
 </send>
-  <recv optional="true" response="100"/>
-  <recv optional="true" response="180"/>
-  <recv optional="true" response="183"/>
+  <recv response="100" optional="true"/>
+  <recv response="180" optional="true"/>
+  <recv response="183" optional="true"/>
   <recv response="200" rrs="true" rtd="true"/>
   <send>
 <![CDATA[


### PR DESCRIPTION
It was an alias of `receive_answer` but `receive_answer` also stores the record set and the response time duration, which you probably don't want to do on every 200 received. Also simplify `wait_for_answer` and fix the documentation, which stated that these expectations are optional by default when they are not.

A couple of other noteworthy points...

Should `send_bye` automatically call `receive_200`? Under normal circumstances, a 200 should always be expected but perhaps someone would want to use Sippy Cup to test abnormal circumstances. Or maybe such a user should be expected to drop back to raw SIPp. I did include `okay` in my new `receive_message` method and `recv response: 200` in my new `send_dtmf` INFO stuff, although the latter really is necessary because it has to be done after every single digit.

The rtd stuff in `receive_answer` doesn't really do anything at present because we're not setting `start_rtd` anywhere. These timers can also be used for more than just answering. Greater control over this would be nice.
