### PR TITLE
[FEATURE] Execute sipp via which

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   * Feature: receive_message for incoming SIP MESSAGEs.
   * Feature: SIP INFO DTMF.
   * Feature: Don't write unnecessary PCAP files.
+  * Feature: Execute sipp via which, allowing sudo rule to be more restrictive.
   * Change: Split `#receive_200` into its own method ([#61](https://github.com/mojolingo/sippy_cup/pull/61))
   * Allow passing arbitrary SIPp options from the YAML manifest
   * Bugfix: Fix ACK/BYE being sent to self.

--- a/lib/sippy_cup/runner.rb
+++ b/lib/sippy_cup/runner.rb
@@ -84,7 +84,7 @@ module SippyCup
 
     def command
       @command ||= begin
-        command = "sudo sipp"
+        command = "sudo $(which sipp)"
         command_options.each_pair do |key, value|
           command << (value ? " -#{key} #{value}" : " -#{key}")
         end

--- a/spec/sippy_cup/runner_spec.rb
+++ b/spec/sippy_cup/runner_spec.rb
@@ -7,7 +7,7 @@ describe SippyCup::Runner do
 
   let(:settings) { {} }
   let(:default_settings) { { logger: logger } }
-  let(:command) { "sudo sipp -i 127.0.0.1" }
+  let(:command) { "sudo $(which sipp) -i 127.0.0.1" }
   let(:pid) { '1234' }
 
   let(:logger) { double }
@@ -47,7 +47,7 @@ steps:
   describe '#run' do
     it "executes the correct command to invoke SIPp" do
       full_scenario_path = File.join(Dir.tmpdir, '/scenario.*')
-      expect_command_execution %r{sudo sipp -i dah.com -p 8836 -sf #{full_scenario_path} -l 5 -m 10 -r 2 -s 1 bar.com}
+      expect_command_execution %r{sudo \$\(which sipp\) -i dah.com -p 8836 -sf #{full_scenario_path} -l 5 -m 10 -r 2 -s 1 bar.com}
       subject.run
     end
 


### PR DESCRIPTION
Not giving an absolute path to sipp means that the sudo rule has to
allow all commands, not just sipp. Now it can be more restrictive.
