### PR TITLE
Support for new `-rate_interval` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # develop
   * Change: Call limits (`number_of_calls`, `concurrent_max` and `calls_per_second`) no longer have default values for simplicity of UAS scenarios. The value of `to_user` now defaults to the SIPp default of `s`.
+  * Feature: Support for setting rate scaling independently of reporting frequency via the new `calls_per_second_interval` option. See also https://github.com/SIPp/sipp/pull/107 and https://github.com/SIPp/sipp/pull/126.
 
 # [0.5.0](https://github.com/mojolingo/sippy_cup/compare/v0.4.1...v0.5.0)
 SYNTAX CHANGES!

--- a/README.markdown
+++ b/README.markdown
@@ -241,7 +241,10 @@ Each parameter has an impact on the test, and may either be changed once the XML
   <dd>The rate at which new calls should be created. Note that SIPp will automatically adjust this downward to stay at or beneath the maximum number of concurrent calls (`concurrent_max`). Defaults to SIP's default of 10</dt>
 
   <dt>calls_per_second_incr</dt>
-  <dd>When used with `calls_per_second_max`, tells SIPp the amount by which `calls_per_second` should be incremented. CPS rate is adjusted each `stats_interval`. Default: 1</dd>
+  <dd>When used with `calls_per_second_max`, tells SIPp the amount by which `calls_per_second` should be incremented. CPS rate is adjusted each `calls_per_second_interval`. Default: 1.</dd>
+
+  <dt>calls_per_second_interval</dt>
+  <dd>When used with `calls_per_second_max`, tells SIPp the time interval (in seconds) by which calls-per-second should be incremented. Default: Unset; SIPp's default (60s). NOTE: Requires a development build of SIPp; see https://github.com/SIPp/sipp/pull/107</dd>
 
   <dt>calls_per_second_max</dt>
   <dd>The maximum rate of calls-per-second. Default: unused (`calls_per_second` will not change)</dd>

--- a/lib/sippy_cup/runner.rb
+++ b/lib/sippy_cup/runner.rb
@@ -114,6 +114,7 @@ module SippyCup
         options[:no_rate_quit] = nil
         options[:rate_max] = @scenario_options[:calls_per_second_max]
         options[:rate_increase] = @scenario_options[:calls_per_second_incr] || 1
+        options[:rate_interval] = @scenario_options[:calls_per_second_interval] if @scenario_options[:calls_per_second_interval]
       end
 
       if @scenario_options[:stats_file]

--- a/spec/sippy_cup/runner_spec.rb
+++ b/spec/sippy_cup/runner_spec.rb
@@ -360,6 +360,7 @@ concurrent_max: 5
 calls_per_second: 2
 calls_per_second_max: 5
 calls_per_second_incr: 2
+calls_per_second_interval: 20
 number_of_calls: 10
 errors_report_file: errors.txt
 steps:
@@ -375,7 +376,7 @@ steps:
       end
 
       it 'should not terminate the test when reaching the rate limit and set the rate limit and increase appropriately' do
-        expect_command_execution(/-no_rate_quit -rate_max 5 -rate_increase 2/)
+        expect_command_execution(/-no_rate_quit -rate_max 5 -rate_increase 2 -rate_interval 20/)
         subject.run
       end
     end


### PR DESCRIPTION
WIP. Relies on SIPp/sipp#107 - do not merge until that is merged.