### PR TITLE
A scenario is not always outbound with limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # develop
+  * Change: Call limits (`number_of_calls`, `concurrent_max` and `calls_per_second`) no longer have default values for simplicity of UAS scenarios. The value of `to_user` now defaults to the SIPp default of `s`.
 
 # [0.5.0](https://github.com/mojolingo/sippy_cup/compare/v0.4.1...v0.5.0)
 SYNTAX CHANGES!

--- a/README.markdown
+++ b/README.markdown
@@ -202,7 +202,7 @@ Each parameter has an impact on the test, and may either be changed once the XML
   <dd>SIP user from which traffic should appear. Defaults to "sipp".</dd>
 
   <dt>to_user</dt>
-  <dd>SIP user to send requests to. Defaults to "1" (as in 1@127.0.0.1).</dd>
+  <dd>SIP user to send requests to. Defaults to `s` (as in `s@127.0.0.1`).</dd>
 
   <dt>transport</dt>
   <dd>Specify the SIP transport. Valid options are `udp` (default) or `tcp`.</dd>
@@ -228,11 +228,14 @@ Each parameter has an impact on the test, and may either be changed once the XML
   <dt>scenario_variables</dt>
   <dd>If you're using sippy_cup to run a SIPp XML file, there may be CSV fields in the scenario ([field0], [field1], etc.). Specify a path to a CSV file containing the required information using this option. (File is semicolon delimeted, information can be found [here](http://sipp.sourceforge.net/doc/reference.html#inffile).)</dd>
 
+  <dt>number_of_calls</dt>
+  <dd>The total number of calls permitted for the entire test. When this limit is reached, the test is over. Defaults to nil.</dd>
+
   <dt>concurrent_max</dt>
-  <dd>The maximum number of calls permitted to be active at any given time. When this limit is reached, SIPp will slow down or stop sending new calls until there it falls below the limit. Default: 5</dd>
+  <dd>The maximum number of calls permitted to be active at any given time. When this limit is reached, SIPp will slow down or stop sending new calls until there it falls below the limit. Defaults to nil.</dd>
 
   <dt>calls_per_second</dt>
-  <dd>The rate at which new calls should be created. Note that SIPp will automatically adjust this downward to stay at or beneath the maximum number of concurrent calls (`concurrent_max`). Default: 10</dt>
+  <dd>The rate at which new calls should be created. Note that SIPp will automatically adjust this downward to stay at or beneath the maximum number of concurrent calls (`concurrent_max`). Defaults to nil.</dt>
 
   <dt>calls_per_second_incr</dt>
   <dd>When used with `calls_per_second_max`, tells SIPp the amount by which calls-per-second should be incremented. CPS rate is adjusted each `stats_interval`. Default: 1.</dd>

--- a/lib/sippy_cup/runner.rb
+++ b/lib/sippy_cup/runner.rb
@@ -99,11 +99,13 @@ module SippyCup
       options = {
         p: @scenario_options[:source_port] || '8836',
         sf: @input_files[:scenario].path,
-        l: @scenario_options[:concurrent_max] || @scenario_options[:max_concurrent] || 5,
-        m: @scenario_options[:number_of_calls] || 10,
-        r: @scenario_options[:calls_per_second] || 10,
-        s: @scenario_options[:to_user] || '1'
       }
+
+      max_concurrent = @scenario_options[:concurrent_max] || @scenario_options[:max_concurrent]
+      options[:l] = max_concurrent if max_concurrent
+      options[:m] = @scenario_options[:number_of_calls] if @scenario_options[:number_of_calls]
+      options[:r] = @scenario_options[:calls_per_second] if @scenario_options[:calls_per_second]
+      options[:s] = @scenario_options[:to_user] if @scenario_options[:to_user]
 
       options[:i] = @scenario_options[:source] if @scenario_options[:source]
       options[:mp] = @scenario_options[:media_port] if @scenario_options[:media_port]

--- a/spec/sippy_cup/runner_spec.rb
+++ b/spec/sippy_cup/runner_spec.rb
@@ -20,9 +20,6 @@ describe SippyCup::Runner do
 name: foobar
 source: 'dah.com'
 destination: 'bar.com'
-concurrent_max: 5
-calls_per_second: 2
-number_of_calls: 10
 steps:
   - invite
   - wait_for_answer
@@ -48,7 +45,7 @@ steps:
   describe '#run' do
     it "executes the correct command to invoke SIPp" do
       full_scenario_path = File.join(Dir.tmpdir, '/scenario.*')
-      expect_command_execution %r{sudo \$\(which sipp\) -p 8836 -sf #{full_scenario_path} -l 5 -m 10 -r 2 -s 1 -i dah.com bar.com}
+      expect_command_execution %r{sudo \$\(which sipp\) -p 8836 -sf #{full_scenario_path} -i dah.com bar.com}
       subject.run
     end
 
@@ -79,6 +76,34 @@ steps:
         subject.stub :process_exit_status
         subject.should_receive :spawn
         Process.should_not_receive :wait2
+        subject.run
+      end
+    end
+
+    context "specifying outbound options in the manifest" do
+      let(:manifest) do
+        <<-MANIFEST
+name: foobar
+source: 'dah.com'
+destination: 'bar.com'
+to_user: 1
+concurrent_max: 5
+calls_per_second: 2
+number_of_calls: 10
+steps:
+  - invite
+  - wait_for_answer
+  - ack_answer
+  - sleep 3
+  - send_digits 'abc'
+  - sleep 5
+  - send_digits '#'
+  - wait_for_hangup
+        MANIFEST
+      end
+
+      it 'should pass the appropriate options to sipp' do
+        expect_command_execution(/-l 5 -m 10 -r 2 -s 1/)
         subject.run
       end
     end


### PR DESCRIPTION
This removes the defaults such that calling limits (maximum concurrent calls, overall maximum number of calls, CPS and target user) are only imposed if specified. UAS scenarios will typically not specify these.