### PR TITLE
Fix specs under ActiveSupport 4

### DIFF
--- a/sippy_cup.gemspec
+++ b/sippy_cup.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'packetfu'
   s.add_runtime_dependency 'nokogiri', ["~> 1.6.0"]
-  s.add_runtime_dependency 'activesupport', ["~> 3.0"]
+  s.add_runtime_dependency 'activesupport', [">= 3.0"]
   s.add_runtime_dependency 'psych', ["~> 2.0.1"] unless RUBY_PLATFORM == 'java'
 
   s.add_development_dependency 'guard-rspec'

--- a/spec/sippy_cup/runner_spec.rb
+++ b/spec/sippy_cup/runner_spec.rb
@@ -450,9 +450,7 @@ steps:
         let(:exit_code) { 0 }
 
         it "doesn't raise anything if SIPp returns 0" do
-          quietly do
-            subject.run.should be true
-          end
+          subject.run.should be true
         end
       end
 
@@ -460,10 +458,8 @@ steps:
         let(:exit_code) { 1 }
 
         it "returns false if SIPp returns 1" do
-          quietly do
-            logger.should_receive(:info).ordered.with(/Test completed successfully but some calls failed./)
-            subject.run.should be false
-          end
+          logger.should_receive(:info).ordered.with(/Test completed successfully but some calls failed./)
+          subject.run.should be false
         end
       end
 
@@ -471,9 +467,7 @@ steps:
         let(:exit_code) { 97 }
 
         it "raises a ExitOnInternalCommand error if SIPp returns 97" do
-          quietly do
-            expect { subject.run }.to raise_error SippyCup::ExitOnInternalCommand, error_string
-          end
+          expect { subject.run }.to raise_error SippyCup::ExitOnInternalCommand, error_string
         end
       end
 
@@ -481,9 +475,7 @@ steps:
         let(:exit_code) { 99 }
 
         it "raises a NoCallsProcessed error if SIPp returns 99" do
-          quietly do
-            expect { subject.run }.to raise_error SippyCup::NoCallsProcessed, error_string
-          end
+          expect { subject.run }.to raise_error SippyCup::NoCallsProcessed, error_string
         end
       end
 
@@ -491,9 +483,7 @@ steps:
         let(:exit_code) { 255 }
 
         it "raises a FatalError error if SIPp returns 255" do
-          quietly do
-            expect { subject.run }.to raise_error SippyCup::FatalError, error_string
-          end
+          expect { subject.run }.to raise_error SippyCup::FatalError, error_string
         end
       end
 
@@ -501,9 +491,7 @@ steps:
         let(:exit_code) { 254 }
 
         it "raises a FatalSocketBindingError error if SIPp returns 254" do
-          quietly do
-            expect { subject.run }.to raise_error SippyCup::FatalSocketBindingError, error_string
-          end
+          expect { subject.run }.to raise_error SippyCup::FatalSocketBindingError, error_string
         end
       end
 
@@ -511,15 +499,11 @@ steps:
         let(:exit_code) { 128 }
 
         it "raises a SippGenericError error if SIPp returns 255" do
-          quietly do
-            expect { subject.run }.to raise_error SippyCup::SippGenericError, error_string
-          end
+          expect { subject.run }.to raise_error SippyCup::SippGenericError, error_string
         end
 
         it "raises a SippGenericError error with the appropriate message" do
-          quietly do
-            expect { subject.run }.to raise_error SippyCup::SippGenericError, error_string
-          end
+          expect { subject.run }.to raise_error SippyCup::SippGenericError, error_string
         end
       end
     end
@@ -537,24 +521,18 @@ steps:
 
       context "by default" do
         it "proxies stdout to the terminal" do
-          quietly do
-            capture(:stdout) { subject.run }.strip.should == output_string
-          end
+          capture(:stdout) { subject.run }.strip.should == output_string
         end
 
         it "proxies stderr to the terminal" do
-          quietly do
-            capture(:stderr) { subject.run }.strip.should == error_string
-          end
+          capture(:stderr) { subject.run }.strip.should == error_string
         end
 
         it "does not leak threads" do
           Thread.list.each { |t| t.kill unless t = Thread.main }
           sleep 0.1
           original_thread_count = active_thread_count
-          quietly do
-            subject.run
-          end
+          subject.run
           sleep 0.1
           active_thread_count.should == original_thread_count
         end
@@ -572,14 +550,12 @@ steps:
         end
 
         it "does not leak threads" do
-          quietly do
-            Thread.list.each { |t| t.kill unless t = Thread.main }
-            sleep 0.1
-            original_thread_count = active_thread_count
-            subject.run
-            sleep 0.1
-            active_thread_count.should == original_thread_count
-          end
+          Thread.list.each { |t| t.kill unless t = Thread.main }
+          sleep 0.1
+          original_thread_count = active_thread_count
+          subject.run
+          sleep 0.1
+          active_thread_count.should == original_thread_count
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,15 +3,52 @@
 %w{
   sippy_cup
   fakefs/spec_helpers
+  tempfile
 }.each { |f| require f }
 
+module SippyCup
+  module SpecHelpers
+    def capture(stream)
+      stream = stream.to_s
+      captured_stream = Tempfile.new(stream)
+      stream_io = eval("$#{stream}")
+      origin_stream = stream_io.dup
+      stream_io.reopen(captured_stream)
+
+      yield
+
+      stream_io.rewind
+      return captured_stream.read
+    ensure
+      captured_stream.close
+      captured_stream.unlink
+      stream_io.reopen(origin_stream)
+    end
+
+    def silence_stream(stream)
+      old_stream = stream.dup
+      stream.reopen(RbConfig::CONFIG['host_os'] =~ /mswin|mingw/ ? 'NUL:' : '/dev/null')
+      stream.sync = true
+      yield
+    ensure
+      stream.reopen(old_stream)
+      old_stream.close
+    end
+  end
+end
+
 RSpec.configure do |config|
+  config.include SippyCup::SpecHelpers
   config.mock_framework = :rspec
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
   config.color = true
 
   config.around(:each) do |example|
-    quietly { example.run }
+    silence_stream(STDOUT) do
+      silence_stream(STDERR) do
+        example.run
+      end
+    end
   end
 end


### PR DESCRIPTION
capture and quietly are deprecated because they are not
thread-safe. That does not matter for these specs and the former is
required for some tests so import the code from ActiveSupport. The
latter isn't strictly required but we might as well bring that across
too.

Since we have a global around block to apply quietly, the individual
invocations of it are not necessary.