### PR TITLE
Permit `To` domain to be different from the destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # develop
+  * Feature: Permit `To` domain to be different from the destination. This permits testing multi-tenant systems more easily.
 
 # [0.6.0](https://github.com/mojolingo/sippy_cup/compare/v0.5.0...v0.6.0)
   * Change: Call limits (`number_of_calls`, `concurrent_max` and `calls_per_second`) no longer have default values for simplicity of UAS scenarios. The value of `to_user` now defaults to the SIPp default of `s`.

--- a/README.markdown
+++ b/README.markdown
@@ -204,6 +204,9 @@ Each parameter has an impact on the test, and may either be changed once the XML
   <dt>to_user</dt>
   <dd>SIP user to send requests to. Defaults to SIPp's default: `s` (as in `s@127.0.0.1`)</dd>
 
+  <dt>to_domain</dt>
+  <dd>SIP domain to send requests to. Defaults to the same as `destination`. Useful for testing multi-tenant systems where the `To` domain is not the same as the hostname of the system.</dd>
+
   <dt>transport</dt>
   <dd>Specify the SIP transport. Valid options are `udp` (default) or `tcp`. Default: `udp`</dd>
 

--- a/README.markdown
+++ b/README.markdown
@@ -201,11 +201,8 @@ Each parameter has an impact on the test, and may either be changed once the XML
   <dt>from_user</dt>
   <dd>SIP user from which traffic should appear. Default: sipp</dd>
 
-  <dt>to_user</dt>
-  <dd>SIP user to send requests to. Defaults to SIPp's default: `s` (as in `s@127.0.0.1`)</dd>
-
-  <dt>to_domain</dt>
-  <dd>SIP domain to send requests to. Defaults to the same as `destination`. Useful for testing multi-tenant systems where the `To` domain is not the same as the hostname of the system.</dd>
+  <dt>to</dt>
+  <dd>SIP user / address to send requests to. Defaults to SIPp's default: `s@[destination]` (as in `s@127.0.0.1`). Can specify either a user (`foouser`) or a full address (`foouser@there.com`), the latter being useful for testing multi-tenant systems where the `To` domain is not the same as the hostname of the system.</dd>
 
   <dt>transport</dt>
   <dd>Specify the SIP transport. Valid options are `udp` (default) or `tcp`. Default: `udp`</dd>

--- a/lib/sippy_cup/runner.rb
+++ b/lib/sippy_cup/runner.rb
@@ -105,7 +105,7 @@ module SippyCup
       options[:l] = max_concurrent if max_concurrent
       options[:m] = @scenario_options[:number_of_calls] if @scenario_options[:number_of_calls]
       options[:r] = @scenario_options[:calls_per_second] if @scenario_options[:calls_per_second]
-      options[:s] = @scenario_options[:to_user] if @scenario_options[:to_user]
+      options[:s] = @scenario_options[:to] if @scenario_options[:to]
 
       options[:i] = @scenario_options[:source] if @scenario_options[:source]
       options[:mp] = @scenario_options[:media_port] if @scenario_options[:media_port]

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -83,8 +83,8 @@ module SippyCup
     # @option options [String] :destination The target system at which to direct traffic.
     # @option options [String] :advertise_address The IP address to advertise in SIP and SDP if different from the bind IP (defaults to the bind IP).
     # @option options [String] :from_user The SIP user from which traffic should appear.
-    # @option options [String] :to_user The SIP user to send requests to.
-    # @option options [String] :to_domain The SIP domain to address requests to. Defaults to the same as `:destination`.
+    # @option options [String] :to_user The SIP user to send requests to. Alias for `:to`.
+    # @option options [String] :to The SIP user / address to send requests to.
     # @option options [Integer] :media_port The RTCP (media) port to bind to locally.
     # @option options [String, Numeric] :max_concurrent The maximum number of concurrent calls to execute.
     # @option options [String, Numeric] :number_of_calls The maximum number of calls to execute in the test run.
@@ -779,7 +779,12 @@ Content-Length: 0
       end
 
       @from_user = args[:from_user] || "sipp"
-      @to_domain = args[:to_domain] || "[remote_ip]"
+
+      args[:to] ||= args[:to_user] if args.has_key?(:to_user)
+      if args[:to]
+        @to_user, @to_domain = args[:to].to_s.split('@')
+      end
+      @to_domain ||= "[remote_ip]"
     end
 
     def compile_media

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -83,7 +83,7 @@ module SippyCup
     # @option options [String] :destination The target system at which to direct traffic.
     # @option options [String] :advertise_address The IP address to advertise in SIP and SDP if different from the bind IP (defaults to the bind IP).
     # @option options [String] :from_user The SIP user from which traffic should appear.
-    # @option options [String] :to_user The SIP user to send requests to. Alias for `:to`.
+    # @option options [String] :to_user The SIP user to send requests to. Alias for `:to` and deprecated in favour of the same.
     # @option options [String] :to The SIP user / address to send requests to.
     # @option options [Integer] :media_port The RTCP (media) port to bind to locally.
     # @option options [String, Numeric] :max_concurrent The maximum number of concurrent calls to execute.
@@ -325,7 +325,7 @@ Content-Type: application/sdp
 Content-Length: [len]
 
 v=0
-o=user1 53655765 2353687637 IN IP[local_ip_type] #{@adv_ip} 
+o=user1 53655765 2353687637 IN IP[local_ip_type] #{@adv_ip}
 s=-
 c=IN IP[media_ip_type] [media_ip]
 t=0 0

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -84,6 +84,7 @@ module SippyCup
     # @option options [String] :advertise_address The IP address to advertise in SIP and SDP if different from the bind IP (defaults to the bind IP).
     # @option options [String] :from_user The SIP user from which traffic should appear.
     # @option options [String] :to_user The SIP user to send requests to.
+    # @option options [String] :to_domain The SIP domain to address requests to. Defaults to the same as `:destination`.
     # @option options [Integer] :media_port The RTCP (media) port to bind to locally.
     # @option options [String, Numeric] :max_concurrent The maximum number of concurrent calls to execute.
     # @option options [String, Numeric] :number_of_calls The maximum number of calls to execute in the test run.
@@ -155,10 +156,9 @@ module SippyCup
       # FIXME: The DTMF mapping (101) is hard-coded. It would be better if we could
       # get this from the DTMF payload generator
       from_addr = "#{@from_user}@#{@adv_ip}:[local_port]"
-      to_addr   = "[service]@[remote_ip]:[remote_port]"
       msg = <<-MSG
 
-INVITE sip:#{to_addr} SIP/2.0
+INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
 Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];branch=[branch]
 From: "#{@from_user}" <sip:#{from_addr}>;tag=[call_number]
 To: <sip:#{to_addr}>
@@ -448,7 +448,7 @@ a=rtpmap:0 PCMU/8000
 ACK [next_url] SIP/2.0
 Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];branch=[branch]
 From: "#{@from_user}" <sip:#{@from_user}@#{@adv_ip}:[local_port]>;tag=[call_number]
-To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+To: <sip:#{to_addr}>[peer_tag_param]
 Call-ID: [call_id]
 CSeq: [cseq] ACK
 Contact: <sip:[$local_addr];transport=[transport]>
@@ -499,7 +499,7 @@ Content-Length: 0
 INFO [next_url] SIP/2.0
 Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];branch=[branch]
 From: "#{@from_user}" <sip:#{@from_user}@#{@adv_ip}:[local_port]>;tag=[call_number]
-To: <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+To: <sip:#{to_addr}>[peer_tag_param]
 Call-ID: [call_id]
 CSeq: [cseq] INFO
 Contact: <sip:[$local_addr];transport=[transport]>
@@ -736,6 +736,10 @@ Content-Length: 0
 
   private
 
+    def to_addr
+      @to_addr ||= "[service]@#{@to_domain}:[remote_port]"
+    end
+
     #TODO: SIPS support?
     def parse_user(user)
       user.slice! 0, 4 if user =~ /sip:/
@@ -774,9 +778,8 @@ Content-Length: 0
         @dtmf_mode = :rfc2833
       end
 
-      @from_addr, @from_port = args[:source].split ':' if args[:source]
-      @to_addr, @to_port = args[:destination].split ':' if args[:destination]
       @from_user = args[:from_user] || "sipp"
+      @to_domain = args[:to_domain] || "[remote_ip]"
     end
 
     def compile_media

--- a/spec/sippy_cup/runner_spec.rb
+++ b/spec/sippy_cup/runner_spec.rb
@@ -86,7 +86,7 @@ steps:
 name: foobar
 source: 'dah.com'
 destination: 'bar.com'
-to_user: 1
+to: 1
 concurrent_max: 5
 calls_per_second: 2
 number_of_calls: 10
@@ -166,7 +166,7 @@ steps:
       end
     end
 
-    context "specifying a to_user in the Scenario" do
+    context "specifying a to in the Scenario" do
       let(:manifest) do
         <<-MANIFEST
 name: foobar
@@ -176,7 +176,7 @@ concurrent_max: 5
 calls_per_second: 2
 number_of_calls: 10
 from_user: pat
-to_user: frank
+to: frank@there.com
 steps:
   - invite
   - wait_for_answer

--- a/spec/sippy_cup/scenario_spec.rb
+++ b/spec/sippy_cup/scenario_spec.rb
@@ -91,6 +91,24 @@ describe SippyCup::Scenario do
         subject.to_xml.should match(%r{Contact: <sip:sipp@})
       end
     end
+
+    context "when a to domain is specified" do
+      let(:args) { {to_domain: 'foo.bar'} }
+
+      it "includes the specified domain in the To header, but not the URI line" do
+        subject.invite
+        subject.to_xml.should match(%r{To: <sip:\[service\]@foo.bar})
+        subject.to_xml.should match(%r{INVITE sip:\[service\]@\[remote_ip\]})
+      end
+    end
+
+    context "when no to domain is specified" do
+      it "uses a default of '[remote_ip]' in the To header and URI line" do
+        subject.invite
+        subject.to_xml.should match(%r{To: <sip:\[service\]@\[remote_ip\]})
+        subject.to_xml.should match(%r{INVITE sip:\[service\]@\[remote_ip\]})
+      end
+    end
   end
 
   describe "#register" do

--- a/spec/sippy_cup/scenario_spec.rb
+++ b/spec/sippy_cup/scenario_spec.rb
@@ -92,17 +92,27 @@ describe SippyCup::Scenario do
       end
     end
 
-    context "when a to domain is specified" do
-      let(:args) { {to_domain: 'foo.bar'} }
+    context "when a to user is specified" do
+      let(:args) { {to: 'usera'} }
 
-      it "includes the specified domain in the To header, but not the URI line" do
+      it "includes the specified user in the To header and URI line" do
+        subject.invite
+        subject.to_xml.should match(%r{To: <sip:\[service\]@\[remote_ip\]})
+        subject.to_xml.should match(%r{INVITE sip:\[service\]@\[remote_ip\]})
+      end
+    end
+
+    context "when a to address is specified" do
+      let(:args) { {to: 'usera@foo.bar'} }
+
+      it "includes the specified address in the To header, but not the URI line" do
         subject.invite
         subject.to_xml.should match(%r{To: <sip:\[service\]@foo.bar})
         subject.to_xml.should match(%r{INVITE sip:\[service\]@\[remote_ip\]})
       end
     end
 
-    context "when no to domain is specified" do
+    context "when no to is specified" do
       it "uses a default of '[remote_ip]' in the To header and URI line" do
         subject.invite
         subject.to_xml.should match(%r{To: <sip:\[service\]@\[remote_ip\]})


### PR DESCRIPTION
This permits testing multi-tenant systems more easily.