### PR TITLE
Permit specifying a custom From domain

### DIFF
--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -155,7 +155,7 @@ module SippyCup
       opts[:retrans] ||= 500
       # FIXME: The DTMF mapping (101) is hard-coded. It would be better if we could
       # get this from the DTMF payload generator
-      from_addr = "#{@from_user}@#{@adv_ip}:[local_port]"
+      from_addr = "#{@from_user}@#{@from_domain || @adv_ip}:[local_port]"
       msg = <<-MSG
 
 INVITE sip:#{to_addr} SIP/2.0
@@ -447,7 +447,7 @@ a=rtpmap:0 PCMU/8000
 
 ACK [next_url] SIP/2.0
 Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];branch=[branch]
-From: "#{@from_user}" <sip:#{@from_user}@#{@adv_ip}:[local_port]>;tag=[call_number]
+From: "#{@from_user}" <sip:#{@from_user}@#{@from_domain || @adv_ip}:[local_port]>;tag=[call_number]
 To: <sip:#{to_addr}>[peer_tag_param]
 Call-ID: [call_id]
 CSeq: [cseq] ACK
@@ -498,7 +498,7 @@ Content-Length: 0
 
 INFO [next_url] SIP/2.0
 Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];branch=[branch]
-From: "#{@from_user}" <sip:#{@from_user}@#{@adv_ip}:[local_port]>;tag=[call_number]
+From: "#{@from_user}" <sip:#{@from_user}@#{@from_domain || @adv_ip}:[local_port]>;tag=[call_number]
 To: <sip:#{to_addr}>[peer_tag_param]
 Call-ID: [call_id]
 CSeq: [cseq] INFO
@@ -779,6 +779,7 @@ Content-Length: 0
       end
 
       @from_user = args[:from_user] || "sipp"
+      @from_domain = args[:from_domain]
 
       args[:to] ||= args[:to_user] if args.has_key?(:to_user)
       if args[:to]

--- a/spec/sippy_cup/scenario_spec.rb
+++ b/spec/sippy_cup/scenario_spec.rb
@@ -84,6 +84,15 @@ describe SippyCup::Scenario do
       end
     end
 
+    context "when a from_domain is specified" do
+      let(:args) { {from_domain: 'foo.bar'} }
+
+      it "includes the specified address in the From header" do
+        subject.invite
+        subject.to_xml.should match(%r{From: "sipp" <sip:sipp@foo.bar:\[local_port\]})
+      end
+    end
+
     context "when no from user is specified" do
       it "uses a default of 'sipp' in the From and Contact headers" do
         subject.invite


### PR DESCRIPTION
This is necessary for scenarios like joining a FreeSWITCH mod_callcenter queue.
