### PR TITLE
Allow SIPp to be launched without sudo

### DIFF
--- a/lib/sippy_cup/runner.rb
+++ b/lib/sippy_cup/runner.rb
@@ -15,6 +15,7 @@ module SippyCup
     # @param [Scenario, XMLScenario] scenario The scenario to execute
     # @param [Hash] opts Options to modify the runner
     # @option opts [optional, true, false] :full_sipp_output Whether or not to copy SIPp's stdout/stderr to the parent process. Defaults to true.
+    # @option opts [optional, true, false] :sudo Whether or not to invoke SIPp with sudo. Defaults to true.
     # @option opts [optional, Logger] :logger A logger to use in place of the internal logger to STDOUT.
     # @option opts [optional, String] :command The command to execute. This is mostly available for testing.
     #
@@ -22,7 +23,7 @@ module SippyCup
       @scenario = scenario
       @scenario_options = @scenario.scenario_options
 
-      defaults = { full_sipp_output: true }
+      defaults = { full_sipp_output: true, sudo: true }
       @options = defaults.merge(opts)
 
       @command = @options[:command]
@@ -87,7 +88,7 @@ module SippyCup
 
     def command
       @command ||= begin
-        command = "sudo $(which sipp)"
+        command = @options[:sudo] ? "sudo $(which sipp)" : 'sipp'
         command_options.each_pair do |key, value|
           command << (value ? " -#{key} #{value}" : " -#{key}")
         end

--- a/spec/sippy_cup/media_spec.rb
+++ b/spec/sippy_cup/media_spec.rb
@@ -11,7 +11,7 @@ describe SippyCup::Media do
   end
 
   it 'should start with an empty sequence' do
-    @media.sequence.should be_empty
+    expect(@media.sequence).to be_empty
   end
 
   it 'should correctly report itself as empty' do
@@ -25,7 +25,7 @@ describe SippyCup::Media do
 
   it 'should append a valid action to the sequence list' do
     @media << 'silence:1000'
-    @media.sequence.include?('silence:1000').should be true
+    expect(@media.sequence.include?('silence:1000')).to be true
   end
 
   it 'should raise an error when assigning an invalid action' do
@@ -35,30 +35,30 @@ describe SippyCup::Media do
   it 'should produce a PcapFile containing 10 packets for 200ms of silence' do
     @media << 'silence:200'
     pf = @media.compile!
-    pf.body.count.should be 10
+    expect(pf.body.count).to be 10
   end
 
   it 'should produce a PcapPacket with 20ms of silence at the end' do
     @media << 'silence:20'
     pf = @media.compile!
     packet = pf.body.first
-    packet.class.should be PacketFu::PcapPacket
-    packet.data[-160, 160].should == 0xff.chr * 160
+    expect(packet.class).to be PacketFu::PcapPacket
+    expect(packet.data[-160, 160]).to eq(0xff.chr * 160)
   end
 
   it 'should produce a PcapPacket with DTMF digit 3, volume 10 at the end' do
     @media << 'dtmf:3'
     pf = @media.compile!
     packet = pf.body.first
-    packet.class.should be PacketFu::PcapPacket
-    packet.data[-4, 4].should == ['030a00a0'].pack('H*')
+    expect(packet.class).to be PacketFu::PcapPacket
+    expect(packet.data[-4, 4]).to eq(['030a00a0'].pack('H*'))
   end
 
   it 'should produce a PcapPacket with DTMF digit #, volume 10 at the end' do
     @media << 'dtmf:#'
     pf = @media.compile!
     packet = pf.body.first
-    packet.class.should be PacketFu::PcapPacket
-    packet.data[-4, 4].should == ['0b0a00a0'].pack('H*')
+    expect(packet.class).to be PacketFu::PcapPacket
+    expect(packet.data[-4, 4]).to eq(['0b0a00a0'].pack('H*'))
   end
 end

--- a/spec/sippy_cup/runner_spec.rb
+++ b/spec/sippy_cup/runner_spec.rb
@@ -49,6 +49,15 @@ steps:
       subject.run
     end
 
+    context 'with sudo disabled' do
+      let(:settings) { {sudo: false} }
+      it "executes the correct command to invoke SIPp" do
+        full_scenario_path = File.join(Dir.tmpdir, '/scenario.*')
+        expect_command_execution %r{sipp -p 8836 -sf #{full_scenario_path} -i dah.com bar.com}
+        subject.run
+      end
+    end
+
     it "ensures that input files are not left on the filesystem" do
       FakeFS do
         Dir.mkdir("/tmp") unless Dir.exist?("/tmp")

--- a/spec/sippy_cup/scenario_spec.rb
+++ b/spec/sippy_cup/scenario_spec.rb
@@ -19,59 +19,59 @@ describe SippyCup::Scenario do
       invite
     end
 
-    s.to_xml.should =~ %r{INVITE sip:\[service\]@\[remote_ip\]:\[remote_port\] SIP/2.0}
+    expect(s.to_xml).to match(%r{INVITE sip:\[service\]@\[remote_ip\]:\[remote_port\] SIP/2.0})
   end
 
   it "allows creating a blank scenario with no block" do
-    subject.to_xml.should =~ %r{<scenario name="Test"/>}
+    expect(subject.to_xml).to match(%r{<scenario name="Test"/>})
   end
 
   describe '#invite' do
     it "sends an INVITE message" do
       subject.invite
 
-      subject.to_xml.should match(%r{<send .*>})
-      subject.to_xml.should match(%r{INVITE})
+      expect(subject.to_xml).to match(%r{<send .*>})
+      expect(subject.to_xml).to match(%r{INVITE})
     end
 
     it "allows setting options on the send instruction" do
       subject.invite foo: 'bar'
 
-      subject.to_xml.should match(%r{<send foo="bar".*>})
+      expect(subject.to_xml).to match(%r{<send foo="bar".*>})
     end
 
     it "defaults to retrans of 500" do
       subject.invite
-      subject.to_xml.should match(%r{<send retrans="500".*>})
+      expect(subject.to_xml).to match(%r{<send retrans="500".*>})
     end
 
     it "allows setting retrans" do
       subject.invite retrans: 200
-      subject.to_xml.should match(%r{<send retrans="200".*>})
+      expect(subject.to_xml).to match(%r{<send retrans="200".*>})
     end
 
     context "with extra headers specified" do
       it "adds the headers to the end of the message" do
         subject.invite headers: "Foo: <bar>\nBar: <baz>"
-        subject.to_xml.should match(%r{Foo: <bar>\nBar: <baz>})
+        expect(subject.to_xml).to match(%r{Foo: <bar>\nBar: <baz>})
       end
 
       it "only has one blank line between headers and SDP" do
         subject.invite headers: "Foo: <bar>\n\n\n"
-        subject.to_xml.should match(%r{Foo: <bar>\n\nv=0})
+        expect(subject.to_xml).to match(%r{Foo: <bar>\n\nv=0})
       end
     end
 
     context "with no extra headers" do
       it "only has one blank line between headers and SDP" do
         subject.invite
-        subject.to_xml.should match(%r{Content-Length: \[len\]\n\nv=0})
+        expect(subject.to_xml).to match(%r{Content-Length: \[len\]\n\nv=0})
       end
     end
 
     it "uses [media_port+1] as the RTCP port in the SDP" do
       subject.invite
-      subject.to_xml.should match(%r{m=audio \[media_port\] RTP/AVP 0 101\n})
+      expect(subject.to_xml).to match(%r{m=audio \[media_port\] RTP/AVP 0 101\n})
     end
 
     context "when a from user is specified" do
@@ -79,16 +79,16 @@ describe SippyCup::Scenario do
 
       it "includes the specified user in the From and Contact headers" do
         subject.invite
-        subject.to_xml.should match(%r{From: "frank" <sip:frank@})
-        subject.to_xml.should match(%r{Contact: <sip:frank@})
+        expect(subject.to_xml).to match(%r{From: "frank" <sip:frank@})
+        expect(subject.to_xml).to match(%r{Contact: <sip:frank@})
       end
     end
 
     context "when no from user is specified" do
       it "uses a default of 'sipp' in the From and Contact headers" do
         subject.invite
-        subject.to_xml.should match(%r{From: "sipp" <sip:sipp@})
-        subject.to_xml.should match(%r{Contact: <sip:sipp@})
+        expect(subject.to_xml).to match(%r{From: "sipp" <sip:sipp@})
+        expect(subject.to_xml).to match(%r{Contact: <sip:sipp@})
       end
     end
 
@@ -97,8 +97,8 @@ describe SippyCup::Scenario do
 
       it "includes the specified user in the To header and URI line" do
         subject.invite
-        subject.to_xml.should match(%r{To: <sip:\[service\]@\[remote_ip\]:\[remote_port\]})
-        subject.to_xml.should match(%r{INVITE sip:\[service\]@\[remote_ip\]:\[remote_port\]})
+        expect(subject.to_xml).to match(%r{To: <sip:\[service\]@\[remote_ip\]:\[remote_port\]})
+        expect(subject.to_xml).to match(%r{INVITE sip:\[service\]@\[remote_ip\]:\[remote_port\]})
       end
     end
 
@@ -107,16 +107,16 @@ describe SippyCup::Scenario do
 
       it "includes the specified address in the To header and URI line" do
         subject.invite
-        subject.to_xml.should match(%r{To: <sip:\[service\]@foo.bar:\[remote_port\]})
-        subject.to_xml.should match(%r{INVITE sip:\[service\]@foo.bar:\[remote_port\]})
+        expect(subject.to_xml).to match(%r{To: <sip:\[service\]@foo.bar:\[remote_port\]})
+        expect(subject.to_xml).to match(%r{INVITE sip:\[service\]@foo.bar:\[remote_port\]})
       end
     end
 
     context "when no to is specified" do
       it "uses a default of '[remote_ip]' in the To header and URI line" do
         subject.invite
-        subject.to_xml.should match(%r{To: <sip:\[service\]@\[remote_ip\]:\[remote_port\]})
-        subject.to_xml.should match(%r{INVITE sip:\[service\]@\[remote_ip\]:\[remote_port\]})
+        expect(subject.to_xml).to match(%r{To: <sip:\[service\]@\[remote_ip\]:\[remote_port\]})
+        expect(subject.to_xml).to match(%r{INVITE sip:\[service\]@\[remote_ip\]:\[remote_port\]})
       end
     end
   end
@@ -125,42 +125,42 @@ describe SippyCup::Scenario do
     it "sends a REGISTER message" do
       subject.register 'frank'
 
-      subject.to_xml.should match(%r{<send.*>})
-      subject.to_xml.should match(%r{REGISTER})
+      expect(subject.to_xml).to match(%r{<send.*>})
+      expect(subject.to_xml).to match(%r{REGISTER})
     end
 
     it "allows setting options on the send instruction" do
       subject.register 'frank', nil, foo: 'bar'
-      subject.to_xml.should match(%r{<send foo="bar".*>})
+      expect(subject.to_xml).to match(%r{<send foo="bar".*>})
     end
 
     it "defaults to retrans of 500" do
       subject.register 'frank'
-      subject.to_xml.should match(%r{<send retrans="500".*>})
+      expect(subject.to_xml).to match(%r{<send retrans="500".*>})
     end
 
     it "allows setting retrans" do
       subject.register 'frank', nil, retrans: 200
-      subject.to_xml.should match(%r{<send retrans="200".*>})
+      expect(subject.to_xml).to match(%r{<send retrans="200".*>})
     end
 
     context "when a domain is provided" do
       it "uses the specified user and domain" do
         subject.register 'frank@foobar.com'
-        subject.to_xml.should match(%r{REGISTER sip:foobar.com})
-        subject.to_xml.should match(%r{From: <sip:frank@foobar.com})
-        subject.to_xml.should match(%r{To: <sip:frank@foobar.com})
-        subject.to_xml.should match(%r{Contact: <sip:sipp@\[local_ip\]})
+        expect(subject.to_xml).to match(%r{REGISTER sip:foobar.com})
+        expect(subject.to_xml).to match(%r{From: <sip:frank@foobar.com})
+        expect(subject.to_xml).to match(%r{To: <sip:frank@foobar.com})
+        expect(subject.to_xml).to match(%r{Contact: <sip:sipp@\[local_ip\]})
       end
     end
 
     context "when a domain is not provided" do
       it "uses the remote IP" do
         subject.register 'frank'
-        subject.to_xml.should match(%r{REGISTER sip:\[remote_ip\]})
-        subject.to_xml.should match(%r{From: <sip:frank@\[remote_ip\]})
-        subject.to_xml.should match(%r{To: <sip:frank@\[remote_ip\]})
-        subject.to_xml.should match(%r{Contact: <sip:sipp@\[local_ip\]})
+        expect(subject.to_xml).to match(%r{REGISTER sip:\[remote_ip\]})
+        expect(subject.to_xml).to match(%r{From: <sip:frank@\[remote_ip\]})
+        expect(subject.to_xml).to match(%r{To: <sip:frank@\[remote_ip\]})
+        expect(subject.to_xml).to match(%r{Contact: <sip:sipp@\[local_ip\]})
       end
     end
 
@@ -168,13 +168,13 @@ describe SippyCup::Scenario do
       it "expects a 401 response" do
         pending "Need to check for initial request, then 401, then retry with authentication"
         subject.register 'frank', 'abc123'
-        subject.to_xml.to match(%r{<recv response="401" auth="true" optional="false"/>})
+        expect(subject.to_xml).to match(%r{<recv response="401" auth="true" optional="false"/>})
         fail "Not yet implemented"
       end
 
       it "adds authentication data to the REGISTER message" do
         subject.register 'frank', 'abc123'
-        subject.to_xml.should match(%r{\[authentication username=frank password=abc123\]})
+        expect(subject.to_xml).to match(%r{\[authentication username=frank password=abc123\]})
       end
     end
   end
@@ -183,19 +183,19 @@ describe SippyCup::Scenario do
     it "expects an optional 100" do
       subject.receive_trying
 
-      scenario.to_xml.should match(%q{<recv response="100" optional="true"/>})
+      expect(scenario.to_xml).to match(%q{<recv response="100" optional="true"/>})
     end
 
     it "allows passing options to the recv expectation" do
       subject.receive_trying foo: 'bar'
 
-      scenario.to_xml.should match(%q{<recv foo="bar" response="100" optional="true"/>})
+      expect(scenario.to_xml).to match(%q{<recv foo="bar" response="100" optional="true"/>})
     end
 
     it "allows overriding options" do
       subject.receive_trying optional: false
 
-      scenario.to_xml.should match(%q{<recv optional="false" response="100"/>})
+      expect(scenario.to_xml).to match(%q{<recv optional="false" response="100"/>})
     end
   end
 
@@ -203,19 +203,19 @@ describe SippyCup::Scenario do
     it "expects an optional 180" do
       subject.receive_ringing
 
-      scenario.to_xml.should match(%q{<recv response="180" optional="true"/>})
+      expect(scenario.to_xml).to match(%q{<recv response="180" optional="true"/>})
     end
 
     it "allows passing options to the recv expectation" do
       subject.receive_ringing foo: 'bar'
 
-      scenario.to_xml.should match(%q{<recv foo="bar" response="180" optional="true"/>})
+      expect(scenario.to_xml).to match(%q{<recv foo="bar" response="180" optional="true"/>})
     end
 
     it "allows overriding options" do
       subject.receive_ringing optional: false
 
-      scenario.to_xml.should match(%q{<recv optional="false" response="180"/>})
+      expect(scenario.to_xml).to match(%q{<recv optional="false" response="180"/>})
     end
   end
 
@@ -223,19 +223,19 @@ describe SippyCup::Scenario do
     it "expects an optional 183" do
       subject.receive_progress
 
-      scenario.to_xml.should match(%q{<recv response="183" optional="true"/>})
+      expect(scenario.to_xml).to match(%q{<recv response="183" optional="true"/>})
     end
 
     it "allows passing options to the recv expectation" do
       subject.receive_progress foo: 'bar'
 
-      scenario.to_xml.should match(%q{<recv foo="bar" response="183" optional="true"/>})
+      expect(scenario.to_xml).to match(%q{<recv foo="bar" response="183" optional="true"/>})
     end
 
     it "allows overriding options" do
       subject.receive_progress optional: false
 
-      scenario.to_xml.should match(%q{<recv optional="false" response="183"/>})
+      expect(scenario.to_xml).to match(%q{<recv optional="false" response="183"/>})
     end
   end
 
@@ -243,19 +243,19 @@ describe SippyCup::Scenario do
     it "expects a 200 with rrs and rtd true" do
       subject.receive_answer
 
-      scenario.to_xml.should match(%q{<recv response="200" rrs="true" rtd="true">})
+      expect(scenario.to_xml).to match(%q{<recv response="200" rrs="true" rtd="true">})
     end
 
     it "allows passing options to the recv expectation" do
       subject.receive_answer foo: 'bar'
 
-      scenario.to_xml.should match(%q{<recv response="200" rrs="true" rtd="true" foo="bar">})
+      expect(scenario.to_xml).to match(%q{<recv response="200" rrs="true" rtd="true" foo="bar">})
     end
 
     it "allows overriding options" do
       subject.receive_answer rtd: false
 
-      scenario.to_xml.should match(%q{<recv response="200" rrs="true" rtd="false">})
+      expect(scenario.to_xml).to match(%q{<recv response="200" rrs="true" rtd="false">})
     end
   end
 
@@ -263,19 +263,19 @@ describe SippyCup::Scenario do
     it "expects a 200" do
       subject.receive_200
 
-      scenario.to_xml.should match(%q{<recv response="200"/>})
+      expect(scenario.to_xml).to match(%q{<recv response="200"/>})
     end
 
     it "allows passing options to the recv expectation" do
       subject.receive_200 foo: 'bar'
 
-      scenario.to_xml.should match(%q{<recv response="200" foo="bar"/>})
+      expect(scenario.to_xml).to match(%q{<recv response="200" foo="bar"/>})
     end
 
     it "allows overriding options" do
       subject.receive_200 response: 999 # Silly but still...
 
-      scenario.to_xml.should match(%q{<recv response="999"/>})
+      expect(scenario.to_xml).to match(%q{<recv response="999"/>})
     end
   end
 
@@ -283,13 +283,13 @@ describe SippyCup::Scenario do
     it "sends an ACK message" do
       subject.ack_answer
 
-      subject.to_xml.should match(%r{<send>})
-      subject.to_xml.should match(%r{ACK})
+      expect(subject.to_xml).to match(%r{<send>})
+      expect(subject.to_xml).to match(%r{ACK})
     end
 
     it "allows setting options on the send instruction" do
       subject.ack_answer foo: 'bar'
-      subject.to_xml.should match(%r{<send foo="bar".*>})
+      expect(subject.to_xml).to match(%r{<send foo="bar".*>})
     end
 
     context "when media is present" do
@@ -301,14 +301,14 @@ describe SippyCup::Scenario do
       it "starts the PCAP media" do
         subject.ack_answer
         subject.sleep 1
-        subject.to_xml(:pcap_path => "/dev/null").should match(%r{<nop>\n.*<action>\n.*<exec play_pcap_audio="/dev/null"/>\n.*</action>\n.*</nop>})
+        expect(subject.to_xml(:pcap_path => "/dev/null")).to match(%r{<nop>\n.*<action>\n.*<exec play_pcap_audio="/dev/null"/>\n.*</action>\n.*</nop>})
       end
     end
 
     context "when media is not present" do
       it "does not start the PCAP media" do
         subject.ack_answer
-        subject.to_xml(:pcap_path => "/dev/null").should_not match(%r{<nop>\n.*<action>\n.*<exec play_pcap_audio="/dev/null"/>\n.*</action>\n.*</nop>})
+        expect(subject.to_xml(:pcap_path => "/dev/null")).not_to match(%r{<nop>\n.*<action>\n.*<exec play_pcap_audio="/dev/null"/>\n.*</action>\n.*</nop>})
       end
     end
   end
@@ -318,49 +318,49 @@ describe SippyCup::Scenario do
       scenario.wait_for_answer
 
       xml = scenario.to_xml
-      xml.should =~ /recv response="100".*optional="true"/
-      xml.should =~ /recv response="180".*optional="true"/
-      xml.should =~ /recv response="183".*optional="true"/
-      xml.should =~ /recv response="200"/
-      xml.should_not =~ /recv response="200".*optional="true"/
-      xml.should match(%r{<send>})
-      xml.should match(%r{ACK})
+      expect(xml).to match(/recv response="100".*optional="true"/)
+      expect(xml).to match(/recv response="180".*optional="true"/)
+      expect(xml).to match(/recv response="183".*optional="true"/)
+      expect(xml).to match(/recv response="200"/)
+      expect(xml).not_to match(/recv response="200".*optional="true"/)
+      expect(xml).to match(%r{<send>})
+      expect(xml).to match(%r{ACK})
     end
 
     it "passes through additional options" do
       scenario.wait_for_answer foo: 'bar'
 
       xml = scenario.to_xml
-      xml.should =~ /recv .*foo="bar".*response="100"/
-      xml.should =~ /recv .*foo="bar".*response="180"/
-      xml.should =~ /recv .*foo="bar".*response="183"/
-      xml.should =~ /recv .*response="200" .*foo="bar"/
-      xml.should match(%r{<send.*foo="bar".*>})
-      xml.should match(%r{ACK})
+      expect(xml).to match(/recv .*foo="bar".*response="100"/)
+      expect(xml).to match(/recv .*foo="bar".*response="180"/)
+      expect(xml).to match(/recv .*foo="bar".*response="183"/)
+      expect(xml).to match(/recv .*response="200" .*foo="bar"/)
+      expect(xml).to match(%r{<send.*foo="bar".*>})
+      expect(xml).to match(%r{ACK})
     end
   end
 
   describe '#receive_message' do
     it "expects a MESSAGE and acks it" do
       subject.receive_message
-      subject.to_xml.should match(%r{<recv request="MESSAGE"/>.*SIP/2\.0 200 OK}m)
+      expect(subject.to_xml).to match(%r{<recv request="MESSAGE"/>.*SIP/2\.0 200 OK}m)
     end
 
     it "allows a string to be given as a regexp for matching" do
       subject.receive_message "Hello World!"
-      subject.to_xml.should match(%r{<action>\s*<ereg regexp="Hello World!" search_in="body" check_it="true" assign_to="[^"]+"/>\s*</action>}m)
+      expect(subject.to_xml).to match(%r{<action>\s*<ereg regexp="Hello World!" search_in="body" check_it="true" assign_to="[^"]+"/>\s*</action>}m)
     end
 
     it "increments the variable name used for regexp matching because SIPp requires it to be unique" do
       subject.receive_message "Hello World!"
       subject.receive_message "Hello Again World!"
       subject.receive_message "Goodbye World!"
-      subject.to_xml.should match(%r{<ereg [^>]* assign_to="([^"]+)_1"/>.*<ereg [^>]* assign_to="\1_2"/>.*<ereg [^>]* assign_to="\1_3"/>}m)
+      expect(subject.to_xml).to match(%r{<ereg [^>]* assign_to="([^"]+)_1"/>.*<ereg [^>]* assign_to="\1_2"/>.*<ereg [^>]* assign_to="\1_3"/>}m)
     end
 
     it "declares the variable used for regexp matching so that SIPp doesn't complain that it's unused" do
       subject.receive_message "Hello World!"
-      subject.to_xml.should match(%r{<ereg [^>]* assign_to="([^"]+)"/>.*<Reference variables="\1"/>}m)
+      expect(subject.to_xml).to match(%r{<ereg [^>]* assign_to="([^"]+)"/>.*<Reference variables="\1"/>}m)
     end
   end
 
@@ -368,13 +368,13 @@ describe SippyCup::Scenario do
     it "sends a BYE message" do
       subject.send_bye
 
-      subject.to_xml.should match(%r{<send>})
-      subject.to_xml.should match(%r{BYE})
+      expect(subject.to_xml).to match(%r{<send>})
+      expect(subject.to_xml).to match(%r{BYE})
     end
 
     it "allows setting options on the send instruction" do
       subject.send_bye foo: 'bar'
-      subject.to_xml.should match(%r{<send foo="bar".*>})
+      expect(subject.to_xml).to match(%r{<send foo="bar".*>})
     end
   end
 
@@ -382,13 +382,13 @@ describe SippyCup::Scenario do
     it "expects a BYE" do
       subject.receive_bye
 
-      scenario.to_xml.should match(%q{<recv request="BYE"/>})
+      expect(scenario.to_xml).to match(%q{<recv request="BYE"/>})
     end
 
     it "allows passing options to the recv expectation" do
       subject.receive_bye foo: 'bar'
 
-      scenario.to_xml.should match(%q{<recv foo="bar" request="BYE"/>})
+      expect(scenario.to_xml).to match(%q{<recv foo="bar" request="BYE"/>})
     end
   end
 
@@ -396,13 +396,13 @@ describe SippyCup::Scenario do
     it "sends a 200 OK" do
       subject.okay
 
-      subject.to_xml.should match(%r{<send>})
-      subject.to_xml.should match(%r{SIP/2.0 200 OK})
+      expect(subject.to_xml).to match(%r{<send>})
+      expect(subject.to_xml).to match(%r{SIP/2.0 200 OK})
     end
 
     it "allows setting options on the send instruction" do
       subject.okay foo: 'bar'
-      subject.to_xml.should match(%r{<send foo="bar".*>})
+      expect(subject.to_xml).to match(%r{<send foo="bar".*>})
     end
   end
 
@@ -410,71 +410,71 @@ describe SippyCup::Scenario do
     it "expects a BYE and acks it" do
       subject.receive_bye foo: 'bar'
 
-      scenario.to_xml.should match(%q{<recv foo="bar" request="BYE"/>})
-      scenario.to_xml.should match(%q{<recv foo="bar" request="BYE"/>})
+      expect(scenario.to_xml).to match(%q{<recv foo="bar" request="BYE"/>})
+      expect(scenario.to_xml).to match(%q{<recv foo="bar" request="BYE"/>})
     end
   end
 
   describe '#call_length_repartition' do
     it 'create a partition table' do
       subject.call_length_repartition('1', '10', '2')
-      scenario.to_xml.should match('<CallLengthRepartition value="1,3,5,7,9"/>')
+      expect(scenario.to_xml).to match('<CallLengthRepartition value="1,3,5,7,9"/>')
     end
   end
 
   describe '#response_time_repartition' do
     it 'create a partition table' do
       subject.response_time_repartition('1', '10', '2')
-      scenario.to_xml.should match('<ResponseTimeRepartition value="1,3,5,7,9"/>')
+      expect(scenario.to_xml).to match('<ResponseTimeRepartition value="1,3,5,7,9"/>')
     end
   end
 
   describe 'media-dependent operations' do
     let(:media) { double :media }
     before do
-      SippyCup::Media.should_receive(:new).once.and_return media
+      expect(SippyCup::Media).to receive(:new).once.and_return media
       scenario.ack_answer
-      media.stub :<<
+      allow(media).to receive :<<
     end
 
     describe '#sleep' do
       it "creates the proper amount of silent audio'" do
-        media.should_receive(:<<).once.with 'silence:5000'
+        expect(media).to receive(:<<).once.with 'silence:5000'
         scenario.sleep 5
       end
 
       it "should insert a pause into the scenario" do
         scenario.sleep 5
-        scenario.to_xml.should match(%r{<pause milliseconds="5000"/>})
+        expect(scenario.to_xml).to match(%r{<pause milliseconds="5000"/>})
       end
 
       context "when passed fractional seconds" do
         it "creates the proper amount of silent audio" do
-          media.should_receive(:<<).once.with 'silence:500'
+          expect(media).to receive(:<<).once.with 'silence:500'
           scenario.sleep '0.5'
         end
 
         it "should insert a pause into the scenario" do
           scenario.sleep 0.5
-          scenario.to_xml.should match(%r{<pause milliseconds="500"/>})
+          expect(scenario.to_xml).to match(%r{<pause milliseconds="500"/>})
         end
       end
     end
 
     describe '#send_digits' do
       it "creates the requested DTMF string in media, with 250ms pauses between" do
-        media.should_receive(:<<).ordered.with 'dtmf:1'
-        media.should_receive(:<<).ordered.with 'silence:250'
-        media.should_receive(:<<).ordered.with 'dtmf:3'
-        media.should_receive(:<<).ordered.with 'silence:250'
-        media.should_receive(:<<).ordered.with 'dtmf:6'
-        media.should_receive(:<<).ordered.with 'silence:250'
+        expect(media).to receive(:<<).ordered.with 'dtmf:1'
+        expect(media).to receive(:<<).ordered.with 'silence:250'
+        expect(media).to receive(:<<).ordered.with 'dtmf:3'
+        expect(media).to receive(:<<).ordered.with 'silence:250'
+        expect(media).to receive(:<<).ordered.with 'dtmf:6'
+        expect(media).to receive(:<<).ordered.with 'silence:250'
         scenario.send_digits '136'
       end
 
       it "should insert a pause into the scenario to cover the DTMF duration (250ms) and the pause" do
         scenario.send_digits '136'
-        scenario.to_xml.should match(%r{<pause milliseconds="1500"/>})
+        expect(scenario.to_xml).to match(%r{<pause milliseconds="1500"/>})
       end
     end
   end
@@ -487,18 +487,18 @@ describe SippyCup::Scenario do
       scenario.send_digits '136'
 
       xml = scenario.to_xml
-      scenario.to_xml.should match(%r{(<send>.*INFO \[next_url\] SIP/2\.0.*</send>.*){3}}m)
-      scenario.to_xml.should match(%r{Signal=1(\nDuration=250\n).*Signal=3\1.*Signal=6\1}m)
+      expect(scenario.to_xml).to match(%r{(<send>.*INFO \[next_url\] SIP/2\.0.*</send>.*){3}}m)
+      expect(scenario.to_xml).to match(%r{Signal=1(\nDuration=250\n).*Signal=3\1.*Signal=6\1}m)
     end
 
     it "expects a response for each digit sent" do
       scenario.send_digits '123'
-      scenario.to_xml.should match(%r{(<send>.*INFO.*</send>.*<recv response="200"/>.*){3}}m)
+      expect(scenario.to_xml).to match(%r{(<send>.*INFO.*</send>.*<recv response="200"/>.*){3}}m)
     end
 
     it "inserts 250ms pauses between each digit" do
       scenario.send_digits '321'
-      scenario.to_xml.should match(%r{(<send>.*INFO.*</send>.*<pause milliseconds="250"/>.*){3}}m)
+      expect(scenario.to_xml).to match(%r{(<send>.*INFO.*</send>.*<pause milliseconds="250"/>.*){3}}m)
     end
   end
 
@@ -509,7 +509,7 @@ describe SippyCup::Scenario do
 
         scenario.compile!
 
-        File.read("/tmp/test.xml").should == scenario.to_xml
+        expect(File.read("/tmp/test.xml")).to eq(scenario.to_xml)
       end
 
       it "writes the PCAP media to disk at name.pcap" do
@@ -518,11 +518,11 @@ describe SippyCup::Scenario do
 
         scenario.compile!
 
-        File.read("/tmp/test.pcap").should_not be_empty
+        expect(File.read("/tmp/test.pcap")).not_to be_empty
       end
 
       it "returns the path to the scenario file" do
-        scenario.compile!.should == "/tmp/test.xml"
+        expect(scenario.compile!).to eq("/tmp/test.xml")
       end
     end
 
@@ -534,7 +534,7 @@ describe SippyCup::Scenario do
 
         scenario.compile!
 
-        File.read("/tmp/foobar.xml").should == scenario.to_xml
+        expect(File.read("/tmp/foobar.xml")).to eq(scenario.to_xml)
       end
 
       it "writes the PCAP media to disk at filename.pcap" do
@@ -543,11 +543,11 @@ describe SippyCup::Scenario do
 
         scenario.compile!
 
-        File.read("/tmp/foobar.pcap").should_not be_empty
+        expect(File.read("/tmp/foobar.pcap")).not_to be_empty
       end
 
       it "returns the path to the scenario file" do
-        scenario.compile!.should == "/tmp/foobar.xml"
+        expect(scenario.compile!).to eq("/tmp/foobar.xml")
       end
     end
   end
@@ -557,19 +557,19 @@ describe SippyCup::Scenario do
 
     it "writes the scenario XML to a Tempfile and returns it" do
       files = scenario.to_tmpfiles
-      files[:scenario].should be_a(Tempfile)
-      files[:scenario].read.should eql(scenario.to_xml)
+      expect(files[:scenario]).to be_a(Tempfile)
+      expect(files[:scenario].read).to eql(scenario.to_xml)
     end
 
     it "allows the scenario XML to be read from disk independently" do
       files = scenario.to_tmpfiles
-      File.read(files[:scenario].path).should eql(scenario.to_xml)
+      expect(File.read(files[:scenario].path)).to eql(scenario.to_xml)
     end
 
     context "without media" do
       it "does not write a PCAP media file" do
         files = scenario.to_tmpfiles
-        files[:media].should be_nil
+        expect(files[:media]).to be_nil
       end
     end
 
@@ -581,18 +581,18 @@ describe SippyCup::Scenario do
 
       it "writes the PCAP media to a Tempfile and returns it" do
         files = scenario.to_tmpfiles
-        files[:media].should be_a(Tempfile)
-        files[:media].read.should_not be_empty
+        expect(files[:media]).to be_a(Tempfile)
+        expect(files[:media].read).not_to be_empty
       end
 
       it "allows the PCAP media to be read from disk independently" do
         files = scenario.to_tmpfiles
-        File.read(files[:media].path).should_not be_empty
+        expect(File.read(files[:media].path)).not_to be_empty
       end
 
       it "puts the PCAP file path into the scenario XML" do
         files = scenario.to_tmpfiles
-        files[:scenario].read.should match(%r{play_pcap_audio="#{files[:media].path}"})
+        expect(files[:scenario].read).to match(%r{play_pcap_audio="#{files[:media].path}"})
       end
     end
   end
@@ -675,7 +675,7 @@ Content-Length: 0
 
       it "runs each step" do
         subject.build(steps)
-        subject.to_xml(:pcap_path => "/dev/null").should == scenario_xml
+        expect(subject.to_xml(:pcap_path => "/dev/null")).to eq(scenario_xml)
       end
     end
 
@@ -689,9 +689,9 @@ Content-Length: 0
       end
 
       it "each method should receive the correct arguments" do
-        subject.should_receive(:register).once.ordered.with('user@domain.com', 'my password has spaces')
-        subject.should_receive(:sleep).once.ordered.with('3')
-        subject.should_receive(:send_digits).once.ordered.with('12345')
+        expect(subject).to receive(:register).once.ordered.with('user@domain.com', 'my password has spaces')
+        expect(subject).to receive(:sleep).once.ordered.with('3')
+        expect(subject).to receive(:send_digits).once.ordered.with('12345')
         subject.build steps
       end
     end
@@ -812,12 +812,12 @@ Content-Length: 0
 
     it "generates the correct XML" do
       scenario = described_class.from_manifest(scenario_yaml)
-      scenario.to_xml(:pcap_path => "/dev/null").should == scenario_xml
+      expect(scenario.to_xml(:pcap_path => "/dev/null")).to eq(scenario_xml)
     end
 
     it "sets the proper options" do
       scenario = described_class.from_manifest(scenario_yaml)
-      scenario.scenario_options.should == {
+      expect(scenario.scenario_options).to eq({
         'name' => 'spec scenario',
         'source' => '192.0.2.15',
         'destination' => '192.0.2.200',
@@ -825,7 +825,7 @@ Content-Length: 0
         'calls_per_second' => 5,
         'number_of_calls' => 20,
         'from_user' => "#{specs_from}"
-      }
+      })
     end
 
     context "when the :scenario key is provided in the manifest" do
@@ -846,8 +846,8 @@ scenario: #{scenario_path}
 
       it "creates an XMLScenario with the scenario XML and nil media" do
         scenario = described_class.from_manifest(scenario_yaml)
-        scenario.should be_a(SippyCup::XMLScenario)
-        scenario.to_xml.should == File.read(scenario_path)
+        expect(scenario).to be_a(SippyCup::XMLScenario)
+        expect(scenario.to_xml).to eq(File.read(scenario_path))
       end
 
       context "and the :media key is provided" do
@@ -871,7 +871,7 @@ media: #{media_path}
           media = File.read(media_path, mode: 'rb')
 
           files = scenario.to_tmpfiles
-          files[:media].read.should eql(media)
+          expect(files[:media].read).to eql(media)
         end
       end
     end
@@ -897,7 +897,7 @@ steps:
 
       it "should default to 'My Scenario'" do
         scenario = described_class.from_manifest(scenario_yaml)
-        scenario.scenario_options[:name].should == 'My Scenario'
+        expect(scenario.scenario_options[:name]).to eq('My Scenario')
       end
     end
 
@@ -905,7 +905,7 @@ steps:
       context "and a name in the manifest" do
         it "uses the name from the manifest" do
           scenario = described_class.from_manifest(scenario_yaml, input_filename: '/tmp/foobar.yml')
-          scenario.scenario_options[:name].should == 'spec scenario'
+          expect(scenario.scenario_options[:name]).to eq('spec scenario')
         end
       end
 
@@ -930,7 +930,7 @@ steps:
 
         it "uses the input filename" do
           scenario = described_class.from_manifest(scenario_yaml, input_filename: '/tmp/foobar.yml')
-          scenario.scenario_options[:name].should == 'foobar'
+          expect(scenario.scenario_options[:name]).to eq('foobar')
         end
       end
     end
@@ -940,12 +940,12 @@ steps:
 
       it "overrides keys with values from the options hash" do
         scenario = described_class.from_manifest(scenario_yaml, override_options)
-        scenario.to_xml(:pcap_path => "/dev/null").should == scenario_xml
+        expect(scenario.to_xml(:pcap_path => "/dev/null")).to eq(scenario_xml)
       end
 
       it "sets the proper options" do
         scenario = described_class.from_manifest(scenario_yaml, override_options)
-        scenario.scenario_options.should == {
+        expect(scenario.scenario_options).to eq({
           'name' => 'spec scenario',
           'source' => '192.0.2.15',
           'destination' => '192.0.2.200',
@@ -953,7 +953,7 @@ steps:
           'calls_per_second' => 5,
           'number_of_calls' => override_options[:number_of_calls],
           'from_user' => "#{specs_from}"
-        }
+        })
       end
     end
 
@@ -983,12 +983,12 @@ steps:
 
       it "sets the validity of the scenario" do
         scenario = SippyCup::Scenario.from_manifest(scenario_yaml)
-        scenario.should_not be_valid
+        expect(scenario).not_to be_valid
       end
 
       it "sets the error messages for the scenario" do
         scenario = SippyCup::Scenario.from_manifest(scenario_yaml)
-        scenario.errors.should == [{step: 4, message: "send_digits 'xyz': Invalid DTMF digit requested: x"}]
+        expect(scenario.errors).to eq([{step: 4, message: "send_digits 'xyz': Invalid DTMF digit requested: x"}])
       end
     end
   end

--- a/spec/sippy_cup/xml_scenario_spec.rb
+++ b/spec/sippy_cup/xml_scenario_spec.rb
@@ -55,31 +55,31 @@ describe SippyCup::XMLScenario do
 
   describe "#to_xml" do
     it "should return the XML representation of the scenario" do
-      subject.to_xml.should == xml
+      expect(subject.to_xml).to eq(xml)
     end
   end
 
   describe "#to_tmpfiles" do
     it "writes the scenario XML to a Tempfile and returns it" do
       files = scenario.to_tmpfiles
-      files[:scenario].should be_a(Tempfile)
-      files[:scenario].read.should eql(xml)
+      expect(files[:scenario]).to be_a(Tempfile)
+      expect(files[:scenario].read).to eql(xml)
     end
 
     it "allows the scenario XML to be read from disk independently" do
       files = scenario.to_tmpfiles
-      File.read(files[:scenario].path).should eql(xml)
+      expect(File.read(files[:scenario].path)).to eql(xml)
     end
 
     it "writes the PCAP media to a Tempfile and returns it" do
       files = scenario.to_tmpfiles
-      files[:media].should be_a(Tempfile)
-      files[:media].read.should eql(media)
+      expect(files[:media]).to be_a(Tempfile)
+      expect(files[:media].read).to eql(media)
     end
 
     it "allows the PCAP media to be read from disk independently" do
       files = scenario.to_tmpfiles
-      File.read(files[:media].path).should eql(media)
+      expect(File.read(files[:media].path)).to eql(media)
     end
 
     context "when media is not provided" do
@@ -87,18 +87,18 @@ describe SippyCup::XMLScenario do
 
       it "should not create a media file" do
         files = scenario.to_tmpfiles
-        files[:media].should be_nil
+        expect(files[:media]).to be_nil
       end
     end
   end
 
   describe "#scenario_options" do
     it "should return options passed to the initializer" do
-      scenario.scenario_options.should == {
+      expect(scenario.scenario_options).to eq({
         name: 'Test',
         source: '127.0.0.1:5060',
         destination: '10.0.0.1:5080'
-      }
+      })
     end
   end
 end


### PR DESCRIPTION
It is not always necessary and it looks like the next version may not need it at all.