### PR TITLE
set event end flag for dtmf digits

### DIFF
--- a/lib/sippy_cup/media.rb
+++ b/lib/sippy_cup/media.rb
@@ -76,7 +76,7 @@ module SippyCup
             #dtmf_frame.rtp_timestamp = timestamp += dtmf_frame.timestamp_interval
             dtmf_frame.rtp_sequence_num = sequence_number += 1
             dtmf_frame.rtp_ssrc_id = ssrc_id
-            dtmf_frame.end_of_event = (count == i) # Last packet?
+            dtmf_frame.end_of_event = ((count-1) == i) # Last packet?
             packet.headers.last.body = dtmf_frame.to_bytes
             packet.recalc
             @pcap_file.body << get_pcap_packet(packet, next_ts(start_time, elapsed))

--- a/spec/sippy_cup/media_spec.rb
+++ b/spec/sippy_cup/media_spec.rb
@@ -61,4 +61,14 @@ describe SippyCup::Media do
     expect(packet.class).to be PacketFu::PcapPacket
     expect(packet.data[-4, 4]).to eq(['0b0a00a0'].pack('H*'))
   end
+
+  it 'should indicate the end of a DTMF digit by setting the End of Event flag' do
+    @media << 'dtmf:1'
+    pf = @media.compile!
+    packet = pf.body.last
+    packet.class.should be PacketFu::PcapPacket
+    packet.data[-4, 4].should == ['018a00a0'].pack('H*')
+  end
+
+
 end


### PR DESCRIPTION
RFC 2833 DTMF digits don't currently get emitted with the media stream (at least as of SIPp 3.5.1) because the end-of-event flag isn't set due to an off-by-one error when generating packets.

This PR fixes the off-by-one error and adds a test to ensure that the flag is in the last packet generated for a digit.