### PR TITLE
PacketFu 1.1.12 didn't really drop PacketFu::UDPPacket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # develop
   * Drop support for Ruby < 2.3.0 - Too many gem dependences require Ruby 2.3, so go along with it rather than fight it
+  * Require PacketFu >= 1.1.13, 1.1.12 was just broken
 
 # [0.7.2](https://github.com/mojolingo/sippy_cup/compare/v0.7.1...v0.7.2)
   * Bugfix: Logical destination for dialog formation belongs in request line

--- a/sippy_cup.gemspec
+++ b/sippy_cup.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'packetfu', ["= 1.1.11"] # 1.1.12 introduces a breaking change, removing PacketFu::UDPPacket
+  s.add_runtime_dependency 'packetfu', [">= 1.1.13"]
   s.add_runtime_dependency 'nokogiri', ["~> 1.8.1"]
   s.add_runtime_dependency 'activesupport', [">= 3.0"]
   s.add_runtime_dependency 'psych', ["~> 2.0.1"] unless RUBY_PLATFORM == 'java'


### PR DESCRIPTION
Loading of the various classes was just a bit broken. 1.1.13 works fine and it supports Ruby 2.4.