### PR TITLE
Robust dtmf packets

### DIFF
--- a/lib/sippy_cup/media/dtmf_payload.rb
+++ b/lib/sippy_cup/media/dtmf_payload.rb
@@ -9,7 +9,7 @@ module SippyCup
       TIMESTAMP_INTERVAL = 160
       END_OF_EVENT = 1 << 7
       DTMF = %w{0 1 2 3 4 5 6 7 8 9 * # A B C D}.freeze
-      attr_accessor :ptime
+      attr_accessor :ptime, :index
 
       def initialize(digit, opts = {})
         super RTP_PAYLOAD_ID
@@ -39,7 +39,7 @@ module SippyCup
       end
 
       def end_of_event
-        @flags & END_OF_EVENT
+        0 < (@flags & END_OF_EVENT)
       end
 
       def media
@@ -47,7 +47,7 @@ module SippyCup
       end
 
       def timestamp_interval
-        TIMESTAMP_INTERVAL
+        TIMESTAMP_INTERVAL * (index.to_i+1)
       end
     end
   end


### PR DESCRIPTION
Made some changes to how RFC 2833 DTMF digits are generated so packets emitted adhere more precisely [to the spec](https://tools.ietf.org/html/rfc2833#section-3.5) and so they are more reliably interpreted on the receiving side.

## Things done:

- DTMF event packets are emitted 20ms apart for approximately 250 ms, instead of all at once
- the duration field in the event payload correlates to the time between the event start timestamp and the packet transmission time
- 3 redundant copies of the end-of-event packet are sent, to guard against packets dropped in transmission.
- added some unit tests to ensure the generated packets are as expected

As a point of reference, the generated digits closely match what is emitted by Twilio SIP trunks, and are being far more reliably interpreted by the SIP server i'm running (freeswitch 1.6.20)