### PR TITLE
Fix setting end-of-event false after it's true

### DIFF
--- a/lib/sippy_cup/media/dtmf_payload.rb
+++ b/lib/sippy_cup/media/dtmf_payload.rb
@@ -24,7 +24,7 @@ module SippyCup
         if bool
           @flags |= END_OF_EVENT
         else
-          @flags &= (0xf - END_OF_EVENT)
+          @flags &= ~END_OF_EVENT
         end
       end
 


### PR DESCRIPTION
Given this setter:

```
dtmf_frame.end_of_event = 1
dtmf_frame.end_of_event = 0
```

It's expected the following getter would return 0:
```
dtmf_frame.end_of_event
#=> 0
```

Actual result:
```
dtmf_frame.end_of_event
#=> 1
```

#### Cause
The previous un-setter is trying to negate END_OF_EVENT, but does so by subtracting `15 - 128`:
```
@flags &= (0xf - END_OF_EVENT)
```
This does not produce the intended effect, and end-of-event remains set.  (Additionally, side effects on other properties in `@flags`  are also possible).

#### Not really a big deal

Rest assured however, this "bug" doesn't actually exhibit bad behavior in sippy_cup.  Because its code never sets dtmf_frame.end_of_event more than 1 time per instance.  There is no place in the code where multiple values are set for end_of_event of the same dtmf_frame instance.  So this is a theoretical bug, at best.