### PR TITLE
Add Authentication Required and Proxy Authentication Required.

### DIFF
--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -833,8 +833,8 @@ Duration=#{delay}
       msg = <<-MSG
 
 BYE [next_url] SIP/2.0
-[last_Record-Route:]
-[last_Via:]
+Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];rport;branch=[branch]
+[routes]
 #{@direction == "outbound" ? "To:" : "From:" } sip:[$remote_addr];tag=[$remote_tag]
 #{@direction == "outbound" ? "From:" : "To:" } sip:[$local_addr];tag=[call_number]
 [last_Call-ID:]

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -838,8 +838,8 @@ Duration=#{delay}
 BYE [next_url] SIP/2.0
 Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];branch=[branch]
 [routes]
-#{@direction == "outbound" ? "To:" : "From:" } sip:[$remote_addr];tag=[$remote_tag]
-#{@direction == "outbound" ? "From:" : "To:" } sip:[$local_addr];tag=[call_number]
+#{@direction == "inbound" ? "To:" : "From:" } sip:[$remote_addr];tag=[$remote_tag]
+#{@direction == "inbound" ? "From:" : "To:" } sip:[$local_addr];tag=[call_number]
 [last_Call-ID:]
 CSeq: [cseq] BYE
 Max-Forwards: 100

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -842,6 +842,7 @@ CSeq: [cseq] BYE
 Max-Forwards: 100
 #{use_contact ? "Contact: <sip:" + @adv_ip + ";transport=[transport]>" : ""}
 User-Agent: #{USER_AGENT}
+Subject: #{@direction}
 Content-Length: 0
       MSG
       send msg, opts

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -604,14 +604,15 @@ Content-Length: 0
 
       ack_msg = <<-BODY
 
-ACK sip:#{to_addr} SIP/2.0
-Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];rport;branch=[branch]
+ACK sip:#{@to_addr} SIP/2.0
+[last_Via:]
 [routes]
 [last_From:]
 [last_To:]
 [last_Call-ID:]
 CSeq: [cseq] ACK
-Max-Forwards: 100
+Subject: User Busy Acknowledged
+Max-Forwards: 70
 Content-Length: 0
 
       BODY

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -836,7 +836,7 @@ Duration=#{delay}
       msg = <<-MSG
 
 BYE [next_url] SIP/2.0
-Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];branch=[branch]
+[last_Via:]
 [routes]
 #{@direction == "inbound" ? "To:" : "From:" } sip:[$remote_addr];tag=[$remote_tag]
 #{@direction == "inbound" ? "From:" : "To:" } sip:[$local_addr];tag=[call_number]

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -686,6 +686,11 @@ Content-Length: 0
       start_media
     end
 
+    def content_body_failure(opts = {})
+      recv(response: opts[:status_code] || 400, auth:true)
+    end
+    alias :receive_400 :content_body_failure
+
     def auth_required(opts = {})
       recv(response: opts[:status_code] || 401, auth:true)
     end

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -12,6 +12,7 @@ module SippyCup
   #
   class Scenario
     USER_AGENT = "SIPp/sippy_cup"
+    UNHOLD= "sendrecv"
     VALID_DTMF = %w{0 1 2 3 4 5 6 7 8 9 0 * # A B C D}.freeze
     MSEC = 1_000
     DEFAULT_RETRANS = 500
@@ -183,6 +184,7 @@ MSG
       from_addr = "#{@from_user}@#{from_domain || @adv_ip + ":[local_port]"}"
       max_forwards = opts[:max_forwards] || 100
       user_agent = opts[:user_agent].present? ? opts[:user_agent]: USER_AGENT
+      hold = opts[:hold].present? ? opts[:hold]: UNHOLD
       msg = <<-MSG
 
 INVITE sip:#{to_addr} SIP/2.0
@@ -204,7 +206,7 @@ c=IN IP[media_ip_type] [media_ip]
 t=0 0
 m=audio [media_port] RTP/AVP 0 101
 a=rtcp-mux
-a=sendrecv
+a=#{hold}
 a=rtpmap:0 PCMU/8000
 a=rtpmap:101 telephone-event/8000
 a=fmtp:101 0-15

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -836,7 +836,7 @@ Duration=#{delay}
       msg = <<-MSG
 
 BYE [next_url] SIP/2.0
-[last_Via:]
+Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];rport;branch=[branch]
 [routes]
 #{@direction == "inbound" ? "To:" : "From:" } sip:[$remote_addr];tag=[$remote_tag]
 #{@direction == "inbound" ? "From:" : "To:" } sip:[$local_addr];tag=[call_number]

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -833,7 +833,7 @@ Duration=#{delay}
       msg = <<-MSG
 
 BYE [next_url] SIP/2.0
-[last_Via:]
+Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];branch=[branch]
 [routes]
 #{@direction == "outbound" ? "To:" : "From:" } sip:[$remote_addr];tag=[$remote_tag]
 #{@direction == "outbound" ? "From:" : "To:" } sip:[$local_addr];tag=[call_number]
@@ -842,7 +842,7 @@ CSeq: [cseq] BYE
 Max-Forwards: 100
 #{use_contact ? "Contact: <sip:" + @adv_ip + ";transport=[transport]>" : ""}
 User-Agent: #{USER_AGENT}
-Subject: #{@direction}
+Subject: dir=#{@direction}
 Content-Length: 0
       MSG
       send msg, opts

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -604,8 +604,8 @@ Content-Length: 0
 
       ack_msg = <<-BODY
 
-ACK [next_url] SIP/2.0
-[last_Via:]
+ACK sip:#{to_addr} SIP/2.0
+Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];rport;branch=[branch]
 [routes]
 [last_From:]
 [last_To:]

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -838,8 +838,8 @@ Duration=#{delay}
 BYE [next_url] SIP/2.0
 Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];rport;branch=[branch]
 [routes]
-#{@direction == "inbound" ? "To:" : "From:" } sip:[$remote_addr];tag=[$remote_tag]
-#{@direction == "inbound" ? "From:" : "To:" } sip:[$local_addr];tag=[call_number]
+To: sip:[$remote_addr];tag=[$remote_tag]
+From: sip:[$local_addr];tag=[call_number]
 [last_Call-ID:]
 CSeq: [cseq] BYE
 Max-Forwards: 100

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -389,6 +389,9 @@ Content-Length: 0
     #
     def send_answer(opts = {})
       opts[:retrans] ||= DEFAULT_RETRANS
+
+      @direction = "inbound"
+
       msg = <<-MSG
 
 SIP/2.0 200 OK

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -604,15 +604,15 @@ Content-Length: 0
 
       ack_msg = <<-BODY
 
-ACK sip:[service]@#{@to_domain} SIP/2.0
-Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];branch=[branch-7]
-From: "#{@from_user}" <sip:#{@from_user}@poc-mike.tncp.textnow.com:[local_port]>;tag=[call_number]
-To: <sip:#{to_addr}>[peer_tag_param]
-Call-ID: [call_id]
+ACK [next_url] SIP/2.0
+[last_Via:]
+[routes]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
 CSeq: [cseq] ACK
 Max-Forwards: 100
 Content-Length: 0
-[routes]
 
       BODY
 

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -627,15 +627,16 @@ Content-Length: 0
 
       ack_msg = <<-BODY
 
-ACK sip:[service]@#{@to_domain} SIP/2.0
-Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];branch=[branch-7]
-From: "#{@from_user}" <sip:#{@from_user}@poc-mike.tncp.textnow.com:[local_port]>;tag=[call_number]
-To: <sip:#{to_addr}>[peer_tag_param]
-Call-ID: [call_id]
-CSeq: [cseq] ACK
-Max-Forwards: 100
-Content-Length: 0
+ACK sip:#{@to_addr} SIP/2.0
+[last_Via:]
 [routes]
+[last_From:]
+[last_To:]
+[last_Call-ID:]
+CSeq: [cseq] ACK
+Subject: Request Terminated Acknowledged
+Max-Forwards: 70
+Content-Length: 0
 
       BODY
 

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -833,7 +833,7 @@ Duration=#{delay}
       msg = <<-MSG
 
 BYE [next_url] SIP/2.0
-Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];rport;branch=[branch]
+[last_Via:]
 [routes]
 #{@direction == "outbound" ? "To:" : "From:" } sip:[$remote_addr];tag=[$remote_tag]
 #{@direction == "outbound" ? "From:" : "To:" } sip:[$local_addr];tag=[call_number]

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -16,7 +16,7 @@ module SippyCup
     MSEC = 1_000
     DEFAULT_RETRANS = 500
 
-    SIP_URI_HEADER_MATCH = '.*<?sip:(.*)>?.*;tag=([^;]*)'
+    SIP_URI_HEADER_MATCH = '.*<?sip:([^>;]*)>?.*;tag=([^;]*)'
 
     #
     # Build a scenario based on either a manifest string or a file handle. Manifests are supplied in YAML format.
@@ -844,7 +844,6 @@ Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];rport;branch=[branch]
 CSeq: [cseq] BYE
 Max-Forwards: 100
 #{use_contact ? "Contact: <sip:" + @adv_ip + ";transport=[transport]>" : ""}
-User-Agent: #{USER_AGENT}
 Subject: dir=#{@direction}
 Content-Length: 0
       MSG

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -510,9 +510,9 @@ Content-Type: application/test
       receive_200(options.merge(opts)) do |recv|
         recv << doc.create_element('action') do |action|
           action << doc.create_element('ereg') do |ereg|
-            ereg['regexp'] = '<sip:(.*)>.*;tag=([^;]*)'
+            ereg['regexp'] = '.*<sip:(.*)>.*;tag=([^;]*)'
             ereg['search_in'] = 'hdr'
-            ereg['header'] = opts[:compact_header] ? 't:' : 'To:'
+            ereg['header'] = opts[:compact_header] ? 'f:' : 'From:'
             ereg['assign_to'] = 'dummy,remote_addr,remote_tag'
           end
         end
@@ -798,7 +798,7 @@ Duration=#{delay}
 BYE [next_url] SIP/2.0
 Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];rport;branch=[branch]
 [routes]
-To: "#{@from_user}" <sip:#{@from_user}@[remote_ip]:[remote_port]>[peer_tag_param]
+To: "#{@from_user}" <sip:[$remote_addr]>;tag=[$remote_tag]
 From: "#{@to_user}" <sip:#{@to_user}@stage.tncp.textnow.com>;tag=[call_number]
 [last_Call-ID:]
 CSeq: [cseq] BYE
@@ -821,8 +821,8 @@ Content-Length: 0
 BYE [next_url] SIP/2.0
 Via: SIP/2.0/[transport] #{@adv_ip}:[local_port];rport;branch=[branch]
 [routes]
-To: "#{@from_user}" <sip:#{@from_user}@[remote_ip]:[remote_port]>[from_tag_param]
-From: "#{@to_user}" <sip:#{@to_user}@stage.tncp.textnow.com>[to_tag_param]
+To: "#{@from_user}" <sip:[$remote_addr]>;tag=[$remote_tag]
+From: "#{@to_user}" <sip:#{@to_user}@stage.tncp.textnow.com>;tag=[call_number]
 [last_Call-ID:]
 Contact: <sip:#{@adv_ip};transport=[transport]>
 Max-Forwards: 100

--- a/lib/sippy_cup/scenario.rb
+++ b/lib/sippy_cup/scenario.rb
@@ -312,13 +312,13 @@ MSG
           end
 
           action << doc.create_element('ereg') do |ereg|
-            ereg['regexp'] = '<?sip:(.*)>?'
+            ereg['regexp'] = '<?sip:([^>;]*)>?'
             ereg['search_in'] = 'hdr'
             ereg['header'] = 't:'
             ereg['assign_to'] = 'dummy,local_addr'
           end
           action << doc.create_element('ereg') do |ereg|
-            ereg['regexp'] = '<?sip:(.*)>?'
+            ereg['regexp'] = '<?sip:([^>;]*)>?'
             ereg['search_in'] = 'hdr'
             ereg['header'] = 'To:'
             ereg['assign_to'] = 'dummy,local_addr'

--- a/spec/sippy_cup/scenario_spec.rb
+++ b/spec/sippy_cup/scenario_spec.rb
@@ -503,9 +503,9 @@ describe SippyCup::Scenario do
       subject.hangup opts
     end
 
-    it 'calls send_by_using_contact and receive_ok when passed a use_contact option' do
+    it 'calls send_bye and receive_ok when passed a use_contact option' do
       opts = { foo: 'bar', use_contact: true }
-      expect(subject).to receive(:send_bye_using_contact).with({ foo: 'bar' })
+      expect(subject).to receive(:send_bye).with({ foo: 'bar' })
       expect(subject).to receive(:receive_ok).with({ foo: 'bar' })
       subject.hangup opts
     end


### PR DESCRIPTION
I found this fork of Sippy Cup that adds these two very useful features.  Authentation and Proxy Auth are difficult enough in sipp that (previously) I just gave up and didn't require authentication in my test infrastructure.  This addition makes the auth effortless.

Auth becomes as simple as:
```
require 'sippy_cup'
scenario = SippyCup::Scenario.new 'Sippy Cup',from_user: "theUsername" do |s|
  s.invite
  s.auth_required
  s.ack_answer
  s.invite headers: ["[authentication username=theUsername password=thePassword]"]
  s.wait_for_answer
  s.ack_answer
  s.sleep 20
  s.hangup
end
```

Proxy auth would mean using
```s.proxy_auth_required ```
instead of 
```   s.auth_required ```





This isn't my code, and I don't know why a pull request was ever created for this, but the only real potential problem as I see it is the method signature for adding a header is now an array, not a string to allow for multiple headers.   If necessary to accept this merge request, it could be removed.  The following commit is where it was added:
https://github.com/Enflick/sippy_cup/commit/6ae9db5884d74c3f9079ff6af324f331fe133fa3